### PR TITLE
tried to implement cooldown before explosion

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/EventTriggerPacket.java
+++ b/src/main/java/net/nuclearteam/createnuclear/multiblock/controller/EventTriggerPacket.java
@@ -10,6 +10,7 @@ import net.nuclearteam.createnuclear.overlay.EventTextOverlay;
 public class EventTriggerPacket extends SimplePacketBase {
     // Duration in ticks for which the overlay should be displayed
     private final int duration;
+    public static int timer = 0;
 
     public EventTriggerPacket(int duration) {
         this.duration = duration;
@@ -28,6 +29,7 @@ public class EventTriggerPacket extends SimplePacketBase {
     @Override
     public boolean handle(Context context) {
         context.enqueueWork(() -> {
+            if (timer > 0) timer--;
             EventTextOverlay.triggerEvent(duration);
         });
         return true;

--- a/src/main/java/net/nuclearteam/createnuclear/overlay/EventTextOverlay.java
+++ b/src/main/java/net/nuclearteam/createnuclear/overlay/EventTextOverlay.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.nuclearteam.createnuclear.CreateNuclear;
+import net.nuclearteam.createnuclear.multiblock.controller.EventTriggerPacket;
 
 /**
  * HUD overlay for displaying localized text when a specific event occurs.
@@ -28,8 +29,8 @@ public class EventTextOverlay implements HudOverlay {
 
     @Override
     public void render(GuiGraphics graphics, float partialTicks) {
-        if (timer-- <= 0) return;
-        CreateNuclear.LOGGER.warn("hum EventTextOverlay: {}", timer);
+        if (EventTriggerPacket.timer <= 0) return;
+        CreateNuclear.LOGGER.warn("hum EventTextOverlay: {}", EventTriggerPacket.timer);
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) return;
         Component text = Component.translatable("overlay.event_message", timer).withStyle(ChatFormatting.RED);

--- a/src/main/java/net/nuclearteam/createnuclear/tools/EventTriggerBlock.java
+++ b/src/main/java/net/nuclearteam/createnuclear/tools/EventTriggerBlock.java
@@ -24,7 +24,7 @@ public class EventTriggerBlock extends Block {
                                  Player player, InteractionHand hand, BlockHitResult hit) {
         if (!level.isClientSide) {
             // Send packet to all clients around this block within 16 blocks
-            EventTriggerPacket packet = new EventTriggerPacket(100); // display for 100 ticks
+            EventTriggerPacket packet = new EventTriggerPacket(1500); // display for 100 ticks
             CreateNuclear.LOGGER.warn("hum EventTriggerBlock ? {}", packet);
             CNPackets.getChannel().sendToClientsAround(packet, (ServerLevel) level, new Vec3(pos.getX(), pos.getY(), pos.getZ()), 16);
         }

--- a/src/main/resources/assets/createnuclear/lang/default/tooltips.json
+++ b/src/main/resources/assets/createnuclear/lang/default/tooltips.json
@@ -59,5 +59,5 @@
   "tag.item.trinkets.head.face": "Head Face",
 
 
-  "overlay.event_message": "⚠ Warning ⚠ %s timer"
+  "overlay.event_message": "⚠ Warning ⚠ %s time left before explosion"
 }


### PR DESCRIPTION
This pull request introduces improvements to the event-trigger and countdown system for the reactor core, enhancing the way warning overlays are displayed to players and how event packets are managed. The changes focus on synchronizing the event overlay timer between server and client, adjusting the warning message, and refining the logic for triggering and resetting overlays based on reactor status.

**Event packet and overlay synchronization:**

* Added a static `timer` variable to `EventTriggerPacket` to facilitate shared countdown state for the overlay across client and server. The timer is decremented when the packet is handled, and the overlay now references this timer for display. [[1]](diffhunk://#diff-f0e375fa736ffd38319c5fd34e20e81798c78811102e16f9a6f09b918a477fbbR13) [[2]](diffhunk://#diff-f0e375fa736ffd38319c5fd34e20e81798c78811102e16f9a6f09b918a477fbbR32) [[3]](diffhunk://#diff-d9961235bc69df5b5e9521ac610a0df6ef2b7ee8c3e78f61d13927032db83c73L31-R33)

**Reactor core countdown and event notification:**

* Updated `ReactorCoreBlockEntity` to send an `EventTriggerPacket` to nearby clients when the reactor enters or exits the danger state. The packet is initialized with the configured explosion countdown, and a reset packet is sent when the danger state clears. [[1]](diffhunk://#diff-99abe96f293c317fb33a04fd91df2aa9d560a4584e5a130895e7aa2187311f64R33-R34) [[2]](diffhunk://#diff-99abe96f293c317fb33a04fd91df2aa9d560a4584e5a130895e7aa2187311f64L45-R67)

**User-facing overlay improvements:**

* Modified the overlay warning message in `tooltips.json` to clarify the meaning of the timer, indicating the time left before explosion.

**Other adjustments:**

* Increased the duration for the event overlay when triggered by `EventTriggerBlock` from 100 to 1500 ticks, providing a longer warning period.
* Added necessary imports to support new functionality and packet handling. [[1]](diffhunk://#diff-99abe96f293c317fb33a04fd91df2aa9d560a4584e5a130895e7aa2187311f64R5) [[2]](diffhunk://#diff-99abe96f293c317fb33a04fd91df2aa9d560a4584e5a130895e7aa2187311f64R14-R23) [[3]](diffhunk://#diff-d9961235bc69df5b5e9521ac610a0df6ef2b7ee8c3e78f61d13927032db83c73R9)

These changes collectively improve the reliability and clarity of the reactor danger warning system for players.