### PR TITLE
Refactor ReactorInputMenu: streamline slot management and enhance click handling with logging

### DIFF
--- a/src/main/java/net/nuclearteam/createnuclear/content/multiblock/input/ReactorInputMenu.java
+++ b/src/main/java/net/nuclearteam/createnuclear/content/multiblock/input/ReactorInputMenu.java
@@ -14,6 +14,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.nuclearteam.createnuclear.CNMenus;
+import net.nuclearteam.createnuclear.CreateNuclear;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -33,16 +34,6 @@ public class ReactorInputMenu extends MenuBase<ReactorInputEntity> {
     }
 
     @Override
-    public ItemStack quickMoveStack(Player player, int index) {
-        Slot clickedSlot = getSlot(index);
-        if (!clickedSlot.hasItem()) return ItemStack.EMPTY;
-        ItemStack stack = clickedSlot.getItem();
-        if (index < 2) moveItemStackTo(stack, 2, slots.size(), false);
-        else moveItemStackTo(stack, 0, 2, false);
-        return ItemStack.EMPTY;
-    }
-
-    @Override
     protected ReactorInputEntity createOnClient(FriendlyByteBuf extraData) {
         ClientLevel world = Minecraft.getInstance().level;
         BlockEntity entity = world.getBlockEntity(extraData.readBlockPos());
@@ -59,22 +50,10 @@ public class ReactorInputMenu extends MenuBase<ReactorInputEntity> {
 
     @Override
     protected void addSlots() {
-        // player Slots
-        for (int hotbarSlot = 0; hotbarSlot < 9; ++hotbarSlot) {
-            this.addSlot(new Slot(player.getInventory(), hotbarSlot, -31 + hotbarSlot * 18, 155));
-        }
+        addSlot(new SlotItemHandler(contentHolder.inventory, 0, 24, 29));
+        addSlot(new SlotItemHandler(contentHolder.inventory, 1, 57, 29));
 
-        for (int row = 0; row < 3; ++row) {
-            for (int col = 0; col < 9; ++col) {
-                this.addSlot(new Slot(player.getInventory(), col + row * 9 + 9, -31 + col * 18, 97 + row * 18));
-            }
-        }
-
-        Slot slot1 = new SlotItemHandler(contentHolder.inventory, 0, 24, 29);
-        Slot slot2 = new SlotItemHandler(contentHolder.inventory, 1, 57, 29);
-
-        addSlot(slot1);
-        addSlot(slot2);
+        addPlayerSlots(-31, 97);
     }
 
     @Override
@@ -82,17 +61,40 @@ public class ReactorInputMenu extends MenuBase<ReactorInputEntity> {
     }
 
     @Override
-    public void clicked(int slotId, int button, ClickType clickType, Player player) {
-        if (clickType == ClickType.THROW) {
-            int[] targetSlotIds = {9, 18, 27, 0, 1, 28, 19, 10, 16, 17, 26, 25, 34, 35, 8, 7};
-            for (int id : targetSlotIds) {
-                if (slotId == id) {
-                    clickType = ClickType.PICKUP;
-                    super.clicked(slotId, button, clickType, player);
-                }
+    public ItemStack quickMoveStack(Player player, int index) {
+        Slot clickedSlot = getSlot(index);
+        if (!clickedSlot.hasItem())
+            return ItemStack.EMPTY;
+        ItemStack stack = clickedSlot.getItem();
+        if (index < 2)
+            moveItemStackTo(stack, 2, slots.size(), false);
+        else {
+            if (moveItemStackTo(stack, 0, 1, false) || moveItemStackTo(stack, 2, 3, false)) {
+                CreateNuclear.LOGGER.warn("Slot moved to empty stack, {}, {}, {}", stack, clickedSlot, index);
             }
-            return;
         }
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+        CreateNuclear.LOGGER.warn("Slot clicked {}, {}, {}", slotId, button, clickType);
         super.clicked(slotId, button, clickType, player);
     }
+
+
+//    @Override
+//    public void clicked(int slotId, int button, ClickType clickType, Player player) {
+//        if (clickType == ClickType.THROW) {
+//            int[] targetSlotIds = {9, 18, 27, 0, 1, 28, 19, 10, 16, 17, 26, 25, 34, 35, 8, 7};
+//            for (int id : targetSlotIds) {
+//                if (slotId == id) {
+//                    clickType = ClickType.PICKUP;
+//                    super.clicked(slotId, button, clickType, player);
+//                }
+//            }
+//            return;
+//        }
+//        super.clicked(slotId, button, clickType, player);
+//    }
 }


### PR DESCRIPTION
This pull request refactors the `ReactorInputMenu` class to simplify slot handling and improve logging for debugging purposes. The main changes include reorganizing how inventory slots are added, restoring and modifying the `quickMoveStack` and `clicked` methods, and adding logging statements to help trace slot interactions.

**Slot handling improvements:**

* Simplified the `addSlots` method by directly adding the two handler slots and using the `addPlayerSlots` helper to add player inventory slots, making the code cleaner and more maintainable.

**Inventory interaction logic:**

* Restored and updated the `quickMoveStack` method to improve item transfer logic between the handler and player inventory slots. Added a warning log when an item is moved to an empty stack for better debugging. [[1]](diffhunk://#diff-6b35ce027d11179a0e4a763def997ba619853a080b7099216d0663194adcacb9L35-L44) [[2]](diffhunk://#diff-6b35ce027d11179a0e4a763def997ba619853a080b7099216d0663194adcacb9L62-R99)

**Logging and debugging enhancements:**

* Overrode the `clicked` method to log all slot click actions, aiding in debugging slot interactions.
* Added import for the `CreateNuclear` class to enable logging.

**Code cleanup:**

* Commented out the previous custom `clicked` method implementation, preserving it for reference while switching to the new logging-based approach.